### PR TITLE
SourcePawn fix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.pwn linguist-language=Pawn
+*.inc linguist-language=Pawn


### PR DESCRIPTION
GitHub struggles to differ between SourcePawn and Pawn (yes, they aren't _really_ the same language). This .gitattributes may take a slight while to take effect.